### PR TITLE
Change the Techlore Dispatch hyperlink to a Techlore Blog hyperlink

### DIFF
--- a/common/footer.html
+++ b/common/footer.html
@@ -89,9 +89,9 @@
                       Go Incognito
                     </a>
                   </li>
-                  <li class="footer-section-link-wrapper techlore-dispatch">
-                    <a class="footer-section-link" href="https://dispatch.techlore.tech/" target="">
-                      Techlore Dispatch
+                  <li class="footer-section-link-wrapper techlore-blog">
+                    <a class="footer-section-link" href="https://blog.techlore.tech/" target="">
+                      Techlore Blog
                     </a>
                   </li>
                   <li class="footer-section-link-wrapper techlore-talks">


### PR DESCRIPTION
Techlore doesn't use Substack anymore and the current Techlore Blog is hosted using Bear Blog.

Source: https://discuss.techlore.tech/t/techlore-new-blog-and-new-podcast-provider/8689